### PR TITLE
fix: always show the label for the "resolved attributes" table

### DIFF
--- a/support/cas-server-support-thymeleaf/src/main/resources/templates/casGenericSuccessView.html
+++ b/support/cas-server-support-thymeleaf/src/main/resources/templates/casGenericSuccessView.html
@@ -16,7 +16,7 @@
             
             <h2 th:utext="#{screen.success.header}">Log In Successful</h2>
             <p th:utext="#{screen.success.success(${authentication.principal.id})}">You, <strong>username</strong>, have successfully logged into the Central Authentication Service. This is what CAS knows about you:However, you are seeing this page because CAS does not know about your target destination and how to get you there. Examine the authentication request again and make sure a target service/application that is authorized and registered with CAS is specified.</p>
-            <p th:unless="${#maps.isEmpty(authentication.principal.attributes)}">
+            <p>
 
                 The following attributes are resolved for <strong th:utext="${authentication.principal.id}" />:
 


### PR DESCRIPTION
This fix makes the label over the "resolved attributes" table (shown after a successful login when "service" is not specified in the request) always displayed - because the table itself is also always shown.

Insight: With the current implementation (possibly due to nesting `<div>` inside `<p>`?), the attributes table is displayed anyway, even when there are only `authentication.attributes` present. So using the `th:unless` condition doesn't make much sense here.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [x] Brief description of changes applied
- [x] Test cases for all modified changes, where applicable -- N/A
- [] The same pull request targeted at the master branch, if applicable -- TODO
- [] Any documentation on how to configure, test -- N/A
- [] Any possible limitations, side effects, etc -- N/A
- [] Reference any other pull requests that might be related -- N/A

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

-->
